### PR TITLE
add Between Our Worlds heterogeneous query

### DIFF
--- a/queries/heterogeneous/betweenourworlds.sparql
+++ b/queries/heterogeneous/betweenourworlds.sparql
@@ -1,7 +1,5 @@
 # 3. Find Anime TV series and their available streaming services
 # Datasources: https://data.betweenourworlds.org/2018-06 https://dbpedia.org/sparql
-PREFIX bow: <https://betweenourworlds.org/ontology/>
-
 SELECT ?animeName ?providerName WHERE {
   ?stream a bow:Stream.
   ?stream bow:object ?anime.

--- a/queries/heterogeneous/betweenourworlds.sparql
+++ b/queries/heterogeneous/betweenourworlds.sparql
@@ -1,0 +1,17 @@
+# 3. Find Anime TV series and their available streaming services
+# Datasources: https://data.betweenourworlds.org/2018-06 https://dbpedia.org/sparql
+PREFIX bow: <https://betweenourworlds.org/ontology/>
+
+SELECT ?animeName ?providerName WHERE {
+  ?stream a bow:Stream.
+  ?stream bow:object ?anime.
+  ?stream bow:providedBy ?provider.
+
+  ?anime a schema:TVSeries .
+  ?anime schema:name ?animeName .
+
+  ?provider foaf:name ?providerName
+
+  FILTER (lang(?animeName) = 'en')
+}
+LIMIT 10

--- a/settings.json
+++ b/settings.json
@@ -39,6 +39,10 @@
     {
       "name": "Harvard Library",
       "url": "http://data.linkeddatafragments.org/harvard"
+    },
+    {
+      "name": "Between Our Worlds 2018-06",
+      "url": "https://data.betweenourworlds.org/2018-06"
     }
   ],
   "prefixes": {

--- a/settings.json
+++ b/settings.json
@@ -57,7 +57,8 @@
     "dbpedia-owl": "http://dbpedia.org/ontology/",
     "dbpprop":     "http://dbpedia.org/property/",
     "ruben":       "https://ruben.verborgh.org/profile/#",
-    "schema":      "http://schema.org/"
+    "schema":      "http://schema.org/",
+    "bow":         "https://betweenourworlds.org/ontology/"
   },
   "queries": "(Will be generated from the 'queries' folder by running the './queries-to-json' script.)"
 }


### PR DESCRIPTION
This query requires both the DBpedia and Between Our Worlds datasets to return results.
The query is

```
PREFIX bow: <https://betweenourworlds.org/ontology/>

SELECT ?animeName ?providerName WHERE {
  ?stream a bow:Stream.
  ?stream bow:object ?anime.
  ?stream bow:providedBy ?provider.

  ?anime a schema:TVSeries .
  ?anime schema:name ?animeName .

  ?provider foaf:name ?providerName

  FILTER (lang(?animeName) = 'en')
}
LIMIT 10
```

(Only the triple with `foaf:name` is available in DBpedia.)