### PR TITLE
Use YASQE as SPARQL query editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Linked Data Fragments client</title>
   <link rel=stylesheet href="styles/ldf-client.css">
+  <link rel=stylesheet href="styles/yasqe.css">
   <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,700italic,400,700">
   <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1">
 </head>
@@ -42,7 +43,7 @@
 
           <div class="query-text-containers">
             <div class="query-text-container" id="tab-sparql">
-              <textarea class="querytext querytext-sparql" placeholder="Write a SPARQL query or select one from the list"></textarea>
+              <textarea class="querytext querytext-sparql yasqe" placeholder="Write a SPARQL query or select one from the list"></textarea>
             </div>
             <div class="query-text-container" id="tab-graphql">
               <a href="https://gist.github.com/rubensworks/9d6eccce996317677d71944ed1087ea6" class="help" target="_blank">What is GraphQL-LD?</a>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8">
   <title>Linked Data Fragments client</title>
-  <link rel=stylesheet href="styles/ldf-client.css">
   <link rel=stylesheet href="styles/yasqe.css">
+  <link rel=stylesheet href="styles/ldf-client.css">
   <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,700italic,400,700">
   <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1">
 </head>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@comunica/actor-init-sparql": "^1.4.0",
     "@comunica/runner": "^1.4.0",
     "n3": "^0.11.3",
-    "rdf-string": "^1.1.1"
+    "rdf-string": "^1.1.1",
+    "yasgui-yasqe": "^2.11.22"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -145,6 +145,7 @@ require('yasgui-yasqe/dist/yasqe.css'); // Make webpack import the css as well
         if (YASQE && $query.hasClass('yasqe')) {
           $query.yasqe = YASQE.fromTextArea($query[0], {
             createShareLink: null,
+            persistent: null,
           });
           $query.yasqe.on('change', function () {
             $query.val($query.yasqe.getValue());
@@ -297,6 +298,7 @@ require('yasgui-yasqe/dist/yasqe.css'); // Make webpack import the css as well
           this.$queryTextsIndexed[f1].val('');
 
         this.$queryTextsIndexed[options.queryFormat].val(value).change();
+        this.$queryTextsIndexed[options.queryFormat].sync();
         this._refreshQueries($queries);
         break;
       case 'queryContext':

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -3,9 +3,11 @@
 
 // This exports the webpacked jQuery.
 window.jQuery = require('../deps/jquery-2.1.0.js');
+var N3 = require('n3');
+
+// Comment out the following two lines if you want to disable YASQE
 var YASQE = require('yasgui-yasqe/src/main.js');
 require('yasgui-yasqe/dist/yasqe.css'); // Make webpack import the css as well
-var N3 = require('n3');
 
 (function ($) {
   // Query UI main entry point, which mimics the jQuery UI widget interface:
@@ -140,7 +142,7 @@ var N3 = require('n3');
         };
 
         // Prettify SPARQL editors with YASQE
-        if ($query.hasClass('yasqe')) {
+        if (YASQE && $query.hasClass('yasqe')) {
           $query.yasqe = YASQE.fromTextArea($query[0], {
             createShareLink: null,
           });

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -3,6 +3,8 @@
 
 // This exports the webpacked jQuery.
 window.jQuery = require('../deps/jquery-2.1.0.js');
+var YASQE = require('yasgui-yasqe/src/main.js');
+require('yasgui-yasqe/dist/yasqe.css'); // Make webpack import the css as well
 var N3 = require('n3');
 
 (function ($) {
@@ -130,6 +132,23 @@ var N3 = require('n3');
           options.query = $query.val();
           $query.edited = true;
         });
+
+        $queryTextsIndexed[type].sync = function () {
+          // Update YASQE editor if applicable
+          if ($query.yasqe && $query.yasqe.getValue() !== options.query)
+            $query.yasqe.setValue(options.query);
+        };
+
+        // Prettify SPARQL editors with YASQE
+        if ($query.hasClass('yasqe')) {
+          $query.yasqe = YASQE.fromTextArea($query[0], {
+            createShareLink: null,
+          });
+          $query.yasqe.on('change', function () {
+            $query.val($query.yasqe.getValue());
+            $query.change();
+          });
+        }
       });
       $queryContexts.each(function () {
         var $queryContext = $(this);
@@ -160,6 +179,7 @@ var N3 = require('n3');
           if ($queryContextsIndexed[options.queryFormat])
             $queryContextsIndexed[options.queryFormat].val(options.queryContext = queryContext).edited = false;
           $queryTextsIndexed[options.queryFormat].val(options.query = query).edited = false;
+          $queryTextsIndexed[options.queryFormat].sync();
 
           // Set the new selected datasources
           var newDatasources = self._getHashedQueryDatasources(self._getSelectedQueryId());

--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -297,6 +297,16 @@ footer {
   font-size: .8em;
 }
 
+.yasqe .CodeMirror {
+  border-radius: 0px 0px 3px 3px;
+  border: 1px solid #999999;
+  border-top: none;
+}
+
+.yasqe .CodeMirror-gutters {
+  border-top: 1px solid #ddd;
+}
+
 @media (max-width: 725px) {
   body {
     padding: .1em 1em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,6 +2164,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+codemirror@5.17.0:
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.17.0.tgz#a9431353373f152fe2851f29502a3aa12c1d6247"
+  integrity sha1-qUMTUzc/FS/ihR8pUCo6oSwdYkc=
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -3931,6 +3936,11 @@ iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
+jquery@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
+
 js-levenshtein@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e"
@@ -5034,6 +5044,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.4.4:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -5892,6 +5907,11 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
+store@^2.0.4:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/store/-/store-2.0.12.tgz#8c534e2a0b831f72b75fc5f1119857c44ef5d593"
+  integrity sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -6631,3 +6651,20 @@ yargs@12.0.1, yargs@^12.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^10.1.0"
+
+yasgui-utils@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/yasgui-utils/-/yasgui-utils-1.6.7.tgz#2bcfc5a315688de3ae6057883d9ae342b205f267"
+  integrity sha1-K8/FoxVojeOuYFeIPZrjQrIF8mc=
+  dependencies:
+    store "^2.0.4"
+
+yasgui-yasqe@^2.11.22:
+  version "2.11.22"
+  resolved "https://registry.yarnpkg.com/yasgui-yasqe/-/yasgui-yasqe-2.11.22.tgz#6da6cc234157924e986cc566f319b09519edd5f3"
+  integrity sha512-8yNcjune6ONTJXJ2s6bZhRXBxyvuNErXjNAIQCbVyQbnG1feZBTR1SPjTKxkFWaCB/f0f19hmJPtcOkLOcOjUw==
+  dependencies:
+    codemirror "5.17.0"
+    jquery "^2.2.4"
+    prettier "^1.4.4"
+    yasgui-utils "^1.6.7"


### PR DESCRIPTION
As suggested in #8, this enables the YASQE query editor for SPARQL queries.

This does increase the main UI asset size from 239 KB to 709 KB, which is above webpack recommended asset limit of 244 KB. This means that people on slow machines/internet connections might have to wait a bit before they can start querying.

@RubenVerborgh Do you think this ^ is a blocker ?

@joachimvh Can you try breaking it? :-)