### PR TITLE
Edit Dockerfile to use multi stage build and nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,41 @@ It allows users to execute SPARQL queries over one or multiple heterogeneous int
 - Run `yarn run production` to generate a production version in the `build` folder.
 
 ## How the browser client works
-The original _Comunica SPARQL_ engine is written for the Node.js environment.
-The [Webpack](https://webpack.js.org/) library makes it compatible with browsers.
+The original _Comunica SPARQL_ engine is written for the Node.js environment. The [Webpack](https://webpack.js.org/) library makes it compatible with browsers.
 
-The query engine itself runs in a background thread
-using [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers).
-The user interface (`ldf-client-ui.js`)
-instructs the worker (`ldf-client-worker.js`) to evaluate queries
-by sending messages,
-and the worker sends results back.
+The query engine itself runs in a background thread using [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers). The user interface (`ldf-client-ui.js`) instructs the worker (`ldf-client-worker.js`) to evaluate queries by sending messages, and the worker sends results back.
 
-### _(Optional)_ Running in a Docker container
+### Running in a Docker container
 
-If you want to rapidly deploy this widget as a microservice, you can build a [Docker](https://www.docker.com/) container as follows:
+Configure your widget by editing the [settings.json](https://github.com/comunica/jQuery-Widget.js/blob/master/settings.json) file.
+
+Next, edit the [queries directory](https://github.com/comunica/jQuery-Widget.js/tree/master/queries) in which you should insert the queries that will be present by default in the widget.
+
+Build the [Docker](https://www.docker.com/) container as follows:
 
 ```bash
-$ docker build -t comunica-sparql-widget .
+docker build -t comunica-sparql-widget .
 ```
-
-Next, configure your widget by creating a `settings.json` file in your working directory based on the [example](https://github.com/comunica/jQuery-Widget.js/blob/master/settings.json).
-Next, create a `queries` directory in which you should insert the queries that will be present by default in the widget, as is done [here](https://github.com/comunica/jQuery-Widget.js/tree/master/queries).
 
 After that, you can run your newly created container by mounting your current folder to the Docker container:
 ```bash
-$ docker run -p 3000:3000 -it --rm -v $(pwd)/:/tmp/ comunica-sparql-widget
+docker run -p 3000:80 -it --rm comunica-sparql-widget
 ```
 
+Settings and queries can be passed at runtime by mounting your custom `queries.json` to the Docker container:
+
+```bash
+# Compile queries.json from settings.json and the files in the queries folder
+./queries-to-json
+
+# Provide the compiled queries.json at runtime
+docker run -v $(pwd)/queries.json:/usr/share/nginx/html/queries.json -p 3000:80 -it --rm comunica-sparql-widget
+```
+
+> Access on http://localhost:3000
+
 ## License
+
 The Linked Data Fragments jQuery Widget was originally written by [Ruben Verborgh](https://ruben.verborgh.org/)
 and ported for Comunica SPARQL by [Ruben Taelman](http://rubensworks.net/).
 


### PR DESCRIPTION
I faced issues trying to run the current Dockerfile:
* The entrypoint `npm start` deploys on 8080, but port 3000 is exposed in Dockerfile and documentation
* I could not access the application when running with `docker run` (I tried with port 3000 and 8080, but none of them were working) 

So I wrote a 2 stages build:
* First stage uses node to compile website for production (using already existing script `npm run production`)
* Second stage uses nginx to deploy the precompiled website (cleaner container with only the necessary files)

Settings and queries can still be passed at runtime by sharing the `queries.json` file as volume to `/usr/share/nginx/html/queries.json` inside the container!

```bash
docker run -v $(pwd)/queries.json:/usr/share/nginx/html/queries.json -p 3000:80 -it --rm comunica-sparql-widget
```

Instructions for Docker have been added to the README

Thanks a lot for this cool widget!