### PR TITLE
Use /tmp for temporary files

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -14,6 +14,12 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    client_body_temp_path /tmp/client_body 1 2;
+    fastcgi_temp_path /tmp/fastcgi 1 2;
+    proxy_temp_path /tmp/proxy;
+    uwsgi_temp_path /tmp/uwsgi;                                                                          
+    scgi_temp_path /tmp/scgi;
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
Nginx needs to store some temporary files:
```
2022/10/03 09:10:52 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

Let's store them in /tmp (instead of giving write permissions to /var/cache/nginx):
- http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path
- http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_temp_path
- http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_temp_path
- http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_temp_path
- http://nginx.org/en/docs/http/ngx_http_scgi_module.html#scgi_temp_path