### PR TITLE
Fix double escaping of ampersands in URLs in execution log

### DIFF
--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -1051,7 +1051,6 @@ if (typeof global.process === 'undefined')
     return lt && '&lt;' || gt && '&gt;' || amp && '&amp;';
   }
   function escapeMatchUrl(match, preUrl, url) {
-    url = escape(url);
     return preUrl + '<a href="' + url + '" target=_blank>' + url + '</a>';
   }
 


### PR DESCRIPTION
For #148. This change causes the execution log to display the correct URL for requests, and also to click through and see the requested resource.