### PR TITLE
#95: make textarea only vertically resizable

### DIFF
--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -14,6 +14,7 @@ html, input, textarea, button, pre {
 
 body {
   max-width: 650px;
+  min-width: fit-content;
   margin: 0 auto;
   padding: 1em 3em;
   background: white;

--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -405,6 +405,10 @@ footer {
   select {
     width: 250px;
   }
+
+  .ldf-client {
+    min-width: 465px;
+  }
 }
 
 

--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -213,6 +213,7 @@ textarea {
   cursor: pointer;
   font-size: .95em;
   background-color: transparent;
+  resize: vertical;
 }
 
 .results {


### PR DESCRIPTION
Closes https://github.com/comunica/jQuery-Widget.js/issues/95

# What
Make text areas only vertically resizable, to not break the layout.

# Testing
Before: 

https://github.com/comunica/jQuery-Widget.js/assets/21260838/864e54fd-3383-4bb4-adec-b0ba0e7ede36

After: 

https://github.com/comunica/jQuery-Widget.js/assets/21260838/2cb4322a-9d0f-40b6-ac2f-d504cdc0ce87