### PR TITLE
fix: duplicate queries.json file generation

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -60,6 +60,9 @@ if (args.h || args.help || args._.length > 1) {
     // Override the baseURL in the webpack config
     webpackConfig.baseURL.replace = baseURL;
 
+    // Override the buildContext in the webpack config
+    webpackConfig.buildContext.dir = destinationPath;
+
     for (const entry of webpackConfig) {
         entry.mode = mode;
         if (entry.output) {

--- a/plugins/MoveFilePlugin.js
+++ b/plugins/MoveFilePlugin.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+
+class MoveFilePlugin {
+
+    /**
+     * Create a new instance of the MoveFilePlugin.
+     * This plugin expects two functions as arguments, because the paths will be different at runtime.
+     * @param getSource method to retrieve the source file path
+     * @param getDestination method to retrieve the destination file path
+     */
+    constructor(getSource, getDestination) {
+        this.getSource = getSource;
+        this.getDestination = getDestination;
+    }
+
+    apply(compiler) {
+        compiler.hooks.afterEmit.tap('MoveFilePlugin', (compilation) => {
+            if (fs.existsSync(this.getSource())) {
+                fs.renameSync(this.getSource(), this.getDestination());
+            }
+        });
+    }
+}
+
+module.exports = MoveFilePlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const MoveFilePlugin = require('./plugins/MoveFilePlugin');
 
 // First check if we can load Comunica form cwd, if not, fallback to the default
 let pathToComunica;
@@ -13,7 +14,7 @@ catch {
   comunicaOverride = false;
 }
 
-// Make this an object so we can mutate it from the top level of the config
+// Make this an object, so we can mutate it from the top level of the config
 // and have the options propagated to the plugins
 const baseURL = {
   search: '<%= baseURL %>',
@@ -21,6 +22,12 @@ const baseURL = {
   // value in production mode.
   replace: 'http://localhost:8080/',
   flags: 'g'
+}
+
+// Make this an object, so we can mutate it from the top level of the config
+// and have the options propagated to the plugins
+const buildContext = {
+  dir: 'build',
 }
 
 module.exports = [
@@ -41,7 +48,6 @@ module.exports = [
       path.join(__dirname, './images/sparql.png'),
       path.join(__dirname, './favicon.ico'),
       path.join(__dirname, './solid-client-id.jsonld'),
-      path.join(process.cwd(), './queries.json'),
     ],
     output: {
       filename: 'scripts/ldf-client-ui.min.js',
@@ -53,6 +59,11 @@ module.exports = [
         jQuery: path.join(__dirname, '/deps/jquery-2.1.0.js'),
       }),
       new webpack.NormalModuleReplacementPlugin(/^comunica-packagejson$/, (process.platform === 'win32' ? '' : '!!json-loader!') + path.join(pathToComunica, '../../package.json')),
+      // Include the generated queries.json file by moving it from the current working directory (where it was generated) to the build path.
+      new MoveFilePlugin(
+          () => path.join(process.cwd(), 'queries.json'),
+          () => path.join(__dirname, `${buildContext.dir}/queries.json`)
+      ),
     ],
     module: {
       rules: [
@@ -155,6 +166,6 @@ module.exports = [
   },
 ];
 
-// Export the baseURL object so we can mutated it
-// in the generate script
+// Export the baseURL and buildContext objects, so we can mutate it in the generate script
 module.exports.baseURL = baseURL;
+module.exports.buildContext = buildContext;


### PR DESCRIPTION
Closes #145 

# Problem
The `queries.json` file was generated twice, once in the current working directory and once in the build directory. The file was first generated in the current working directory, and then passed to webpack for bundling. This bundling copied the file to the build directory, causing the file to exist twice. 

# Solution
Removed the `queries.json` file from the entries in the webpack plugin and instead wrote a custom plugin that moves this file into the build folder when webpack is triggered.