### PR TITLE
Make yarn-run-dev not move queries.json to build folder

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -85,4 +85,7 @@ if (args.h || args.help || args._.length > 1) {
 
         fs.unlinkSync('.tmp-comunica-engine.js');
     });
+    if (fs.existsSync(path.join(process.cwd(), 'queries.json'))) {
+        fs.renameSync(path.join(process.cwd(), 'queries.json'), path.join(process.cwd(), `${destinationPath}/queries.json`));
+    };
 })();


### PR DESCRIPTION
Calling `yarn run dev` would result in the queries.json file being moved to `build/` after generation resulting in missing data sources and queries in the development server.
This PR changes lets that `move` happen outside of webpack so it doesn't happen when running `yarn run dev`, only when running `yarn run build`.