### PR TITLE
Prevent duplicate prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "n3": "^1.16.2",
     "rdf-string": "^1.6.1",
     "relative-to-absolute-iri": "^1.0.6",
+    "sparqljs": "^3.7.3",
     "string-replace-loader": "^3.1.0",
     "webpack": "^5.69.0",
     "webpack-cli": "^4.9.2",

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -727,21 +727,17 @@ if (typeof global.process === 'undefined')
           return { type: type, value: datasource };
         }),
       };
-      // Add pre-defined prefixes to query
-      var prefixesString = '';
-      if (this.options.queryFormat === 'sparql') {
-        for (var prefix in this.options.prefixes)
-          prefixesString += 'PREFIX ' + prefix + ': <' + this.options.prefixes[prefix] + '>\n';
-      }
-      let query = prefixesString + this.$queryTextsIndexed[this.options.queryFormat].val();
 
-      // Remove duplicate prefixes
-      const parsedQuery = new SparqlParser({ sparqlStar: true }).parse(query);
-      const generatedQuery = new SparqlGenerator({}).stringify(parsedQuery);
+      let query = this.$queryTextsIndexed[this.options.queryFormat].val();
+      if (this.options.queryFormat === 'sparql') {
+        // Add pre-defined prefixes to query and remove duplicates
+        const parsedQuery = new SparqlParser({ prefixes:this.options.prefixes, sparqlStar: true }).parse(query);
+        query = new SparqlGenerator({}).stringify(parsedQuery);
+      }
 
       this._queryWorker.postMessage({
         type: 'query',
-        query: generatedQuery,
+        query: query,
         context: context,
         resultsToTree: this.options.resultsToTree,
       });

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -711,6 +711,17 @@ if (typeof global.process === 'undefined')
       this._resultCount = 0;
       this._startTimer();
 
+      // Replace prefixes from queries.json with prefixes from the query
+      let queryWithoutPrefixes = '';
+      for (const line of this.$queryTextsIndexed[this.options.queryFormat].val().split('\n')) {
+        let prefixMatch = line.match(/^[ \t]*PREFIX[ \t]*([^:]+):[ \t]*<([^)]+)>/);
+        if (prefixMatch === null)
+          queryWithoutPrefixes = queryWithoutPrefixes.concat(`${line}\n`);
+        else
+          // Add or update current prefix in this.options.prefixes
+          this.options.prefixes[prefixMatch[1]] = prefixMatch[2];
+      }
+
       // Let the worker execute the query
       var context = {
         ...this._getQueryContext(),
@@ -730,7 +741,7 @@ if (typeof global.process === 'undefined')
         for (var prefix in this.options.prefixes)
           prefixesString += 'PREFIX ' + prefix + ': <' + this.options.prefixes[prefix] + '>\n';
       }
-      var query = prefixesString + this.$queryTextsIndexed[this.options.queryFormat].val();
+      let query = prefixesString + queryWithoutPrefixes;
       this._queryWorker.postMessage({
         type: 'query',
         query: query,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8371,7 +8371,18 @@ sparqljs@^3.7.1:
   dependencies:
     rdf-data-factory "^1.1.2"
 
+<<<<<<< HEAD
 sparqljson-parse@^2.0.0:
+=======
+sparqljs@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.3.tgz#075821d51ef4954284e36569503fe5558cfb71b0"
+  integrity sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==
+  dependencies:
+    rdf-data-factory "^1.1.2"
+
+sparqljson-parse@^2.0.0, sparqljson-parse@^2.2.0:
+>>>>>>> 4b2295e (Implement deduplicating via sparql.js)
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
   integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8357,7 +8357,7 @@ sparqlalgebrajs@^4.3.7, sparqlalgebrajs@^4.3.8:
     rdf-terms "^1.10.0"
     sparqljs "^3.7.1"
 
-sparqljs@^3.0.0:
+sparqljs@^3.0.0, sparqljs@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.3.tgz#075821d51ef4954284e36569503fe5558cfb71b0"
   integrity sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==
@@ -8371,18 +8371,7 @@ sparqljs@^3.7.1:
   dependencies:
     rdf-data-factory "^1.1.2"
 
-<<<<<<< HEAD
 sparqljson-parse@^2.0.0:
-=======
-sparqljs@^3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.3.tgz#075821d51ef4954284e36569503fe5558cfb71b0"
-  integrity sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==
-  dependencies:
-    rdf-data-factory "^1.1.2"
-
-sparqljson-parse@^2.0.0, sparqljson-parse@^2.2.0:
->>>>>>> 4b2295e (Implement deduplicating via sparql.js)
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
   integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==


### PR DESCRIPTION
Fixing Issue #149.

Some questions:
Should I also account for "PREFIX" not being written all caps in the query?
Can I assume that PREFIX lines start with PREFIX or with only whitespace before?
Can I assume that each PREFIX declaration is on a seperate line starting with PREFIX? Or could there be multiple?
Can prefixes be declared deeper in the query or only at the top?
