### PR TITLE
feat: improve error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@
         </li>
 
         <li>
+          <div class="error-banner"></div>
+        </li>
+
+        <li>
           <label>Query results</label>
           <div class="results"></div>
         </li>

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -773,7 +773,7 @@ if (typeof global.process === 'undefined')
         this._resultAppender('# ' + error.message);
         this.$resultsText.show();
       }
-      
+
       this._resultAppender.flush();
       this._logAppender.flush();
       this._writeResult = this._writeEnd = null;

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -102,7 +102,7 @@ if (typeof global.process === 'undefined')
           $queries = this.$queries = $('.query', $element),
           $log = $('.log', $element),
           $results = $('.results', $element),
-          $resultsText = this.$resultsText = $('<div>', { class: 'text' }),
+          $resultsText = $('<div>', { class: 'text' }),
           $errorBanner = this.$errorBanner = $('.error-banner', $element),
           $datasources = this.$datasources = $('.datasources', $element),
           $datetime = this.$datetime = $('.datetime', $element),

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -102,7 +102,7 @@ if (typeof global.process === 'undefined')
           $queries = this.$queries = $('.query', $element),
           $log = $('.log', $element),
           $results = $('.results', $element),
-          $resultsText = $('<div>', { class: 'text' }),
+          $resultsText = this.$resultsText = $('<div>', { class: 'text' }),
           $datasources = this.$datasources = $('.datasources', $element),
           $datetime = this.$datetime = $('.datetime', $element),
           $httpProxy = this.$httpProxy = $('.httpProxy', $element),
@@ -243,6 +243,7 @@ if (typeof global.process === 'undefined')
 
       // Set up results
       $results.append($resultsText);
+      $resultsText.hide();
       this._resultsScroller = new FastScroller($results, renderResult);
       this._resultAppender = appenderFor($resultsText);
       this._logAppender = appenderFor($log);
@@ -699,6 +700,7 @@ if (typeof global.process === 'undefined')
       this._resultsScroller.removeAll();
       this._resultAppender.clear();
       this._logAppender.clear();
+      this.$resultsText.hide();
 
       // Reset worker if we want to bypass the cache
       if (this.options.bypassCache)
@@ -767,8 +769,11 @@ if (typeof global.process === 'undefined')
       this.$stop.hide();
       this.$start.show();
 
-      if (error && error.message)
+      if (error && error.message) {
         this._resultAppender('# ' + error.message);
+        this.$resultsText.show();
+      }
+      
       this._resultAppender.flush();
       this._logAppender.flush();
       this._writeResult = this._writeEnd = null;

--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -103,6 +103,7 @@ if (typeof global.process === 'undefined')
           $log = $('.log', $element),
           $results = $('.results', $element),
           $resultsText = this.$resultsText = $('<div>', { class: 'text' }),
+          $errorBanner = this.$errorBanner = $('.error-banner', $element),
           $datasources = this.$datasources = $('.datasources', $element),
           $datetime = this.$datetime = $('.datetime', $element),
           $httpProxy = this.$httpProxy = $('.httpProxy', $element),
@@ -243,10 +244,11 @@ if (typeof global.process === 'undefined')
 
       // Set up results
       $results.append($resultsText);
-      $resultsText.hide();
+      $errorBanner.hide();
       this._resultsScroller = new FastScroller($results, renderResult);
       this._resultAppender = appenderFor($resultsText);
       this._logAppender = appenderFor($log);
+      this._errorAppender = appenderFor($errorBanner);
       this.$timing = $('.timing', $element);
 
       // Set the default proxy
@@ -700,7 +702,8 @@ if (typeof global.process === 'undefined')
       this._resultsScroller.removeAll();
       this._resultAppender.clear();
       this._logAppender.clear();
-      this.$resultsText.hide();
+      this._errorAppender.clear();
+      this.$errorBanner.hide();
 
       // Reset worker if we want to bypass the cache
       if (this.options.bypassCache)
@@ -770,12 +773,13 @@ if (typeof global.process === 'undefined')
       this.$start.show();
 
       if (error && error.message) {
-        this._resultAppender('# ' + error.message);
-        this.$resultsText.show();
+        this._errorAppender(error.message);
+        this.$errorBanner.show();
       }
 
       this._resultAppender.flush();
       this._logAppender.flush();
+      this._errorAppender.flush();
       this._writeResult = this._writeEnd = null;
     },
 

--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -216,6 +216,15 @@ textarea {
   resize: vertical;
 }
 
+.error-banner {
+  background-color: #be1622;
+  color: #fff;
+  padding: 8px;
+  border-radius: 3px;
+  font-size: 13px;
+  font-weight: bold;
+}
+
 .results {
   height: 23.5em;
   font-size: 10pt;
@@ -261,11 +270,6 @@ textarea {
 .results .text {
   white-space: pre-wrap;
   margin-right: -999999px; /* avoid that long URLs alter body width */
-  background-color: #be1622;
-  color: #fff;
-  padding: 5px 8px;
-  border-radius: 3px;
-  font-weight: bold;
 }
 
 .log {

--- a/styles/ldf-client.css
+++ b/styles/ldf-client.css
@@ -261,6 +261,11 @@ textarea {
 .results .text {
   white-space: pre-wrap;
   margin-right: -999999px; /* avoid that long URLs alter body width */
+  background-color: #be1622;
+  color: #fff;
+  padding: 5px 8px;
+  border-radius: 3px;
+  font-weight: bold;
 }
 
 .log {


### PR DESCRIPTION
Instead of simply appending the error to the results box, we show a banner instead.

Fix #106

Before:
![localhost_8081_](https://github.com/user-attachments/assets/490be854-2e66-4453-9446-b380da4baa4e)

After:
![localhost_8081_ (1)](https://github.com/user-attachments/assets/2828dd81-ca35-44b6-9f7d-b17736f12297)

cc @rubensworks 