### PR TITLE
fix: #87 update query and context display

### DIFF
--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -208,10 +208,10 @@ if (typeof global.process === 'undefined')
       });
       $queries.chosen({ skip_no_results: true, placeholder_text: ' ' });
       $queries.change(function (query) {
-        if ((options.query !== $queries.val()) && (query = $queries.val())) {
+        var queryContext = $queries.find(':selected').attr('queryContext');
+        if ((options.query !== $queries.val() || options.queryContext !== queryContext) && (query = $queries.val())) {
           // Set the query text
           self._setOption('queryFormat', $queries.find(':selected').attr('queryFormat'));
-          var queryContext = $queries.find(':selected').attr('queryContext');
           if ($queryContextsIndexed[options.queryFormat])
             $queryContextsIndexed[options.queryFormat].val(options.queryContext = queryContext).edited = false;
           $queryTextsIndexed[options.queryFormat].val(options.query = query).edited = false;


### PR DESCRIPTION
## Description

if the selected query has the same query but different context as described in issue #87 the context would not update. 
with this additional check to see if the context differs as well both get updated

## How to reproduce:

use the queries from this repository (from the issue creator):
https://github.com/KasperZutterman/datascience-comunica-client/tree/master/queries/kadaster

and test the [buurt-in-gemeente-reverse](https://github.com/KasperZutterman/datascience-comunica-client/blob/master/queries/kadaster/buurt-in-gemeente-reverse.graphql) and [buurt-in-gemeente](https://github.com/KasperZutterman/datascience-comunica-client/blob/master/queries/kadaster/buurt-in-gemeente.graphql) queries
