### PR TITLE
feat: buffer map results and move to non-blocking

### DIFF
--- a/src/ldf-client-ui.js
+++ b/src/ldf-client-ui.js
@@ -916,11 +916,9 @@ if (typeof global.process === 'undefined')
       if (!this._mapResultsBuffer) this._mapResultsBuffer = [];
       this._mapResultsBuffer.push(bindings);
 
-      if (this._mapResultsBuffer.length > 0) {
-        if (!this._processingScheduled) {
-          this._processingScheduled = true;
-          requestAnimationFrame(this._processMapData.bind(this));
-        }
+      if (!this._processingScheduled) {
+        this._processingScheduled = true;
+        requestAnimationFrame(this._processMapData.bind(this));
       }
     },
 


### PR DESCRIPTION
## Description

use requestAnimationFrame to handle the parsing and updating of the map in between renderes of the browser
also use buffering to add as much points as possible

### Relaxed Issue
#90 